### PR TITLE
chore: included broker tests to the build & fix createClient

### DIFF
--- a/.changeset/green-eagles-walk.md
+++ b/.changeset/green-eagles-walk.md
@@ -1,0 +1,5 @@
+---
+'vue-paho-mqtt': patch
+---
+
+included utility broker tests to the build, fixed client unit test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,19 +10,19 @@
 
 These are the useful scripts that you can use while developing. You can find them in the `package.json` file. You can run them by using `npm run <script_name>`.
 
-| Script             | Description                                    |
-| ------------------ | ---------------------------------------------- |
-| `dev`              | Start the development environment              |
-| `build`            | Test and build the app and the `live-demo`     |
-| `build:live-demo`  | Only build the `live-demo`                     |
-| `preview`          | Run the app on _preview_ mode                  |
-| `generate:types`   | Generate all the types for the project         |
-| `changeset`        | Adds a changelog to the project after a change |
-| `test`             | Run the tests excluding the broker tests       |
-| `test:watch`       | Watch the tests excluding the broker tests     |
-| `test:utils`       | Run the tests including the broker tests       |
-| `test:utils:watch` | Watch the tests including the broker tests     |
-| `test:coverage`    | Create a coverage report for the tests         |
+| Script                 | Description                                    |
+| ---------------------- | ---------------------------------------------- |
+| `dev`                  | Start the development environment              |
+| `build`                | Test and build the app and the `live-demo`     |
+| `build:live-demo`      | Only build the `live-demo`                     |
+| `preview`              | Run the app on _preview_ mode                  |
+| `generate:types`       | Generate all the types for the project         |
+| `changeset`            | Adds a changelog to the project after a change |
+| `test`                 | Run the tests once                             |
+| `test:watch`           | Watch the tests                                |
+| `test:no-broker`       | Run the tests excluding the broker tests       |
+| `test:no-broker:watch` | Watch the tests excluding the broker tests     |
+| `test:coverage`        | Create a coverage report for the tests         |
 
 When pushing your changes, always include a **changeset** file. You can do this by running the `changeset` script. It will ask you a few questions and then create a file for you. You can read more about it [here](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
 

--- a/package.json
+++ b/package.json
@@ -45,16 +45,16 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "npm run test && vite build --mode prod && npm run generate:types && npm run build:live-demo",
+    "build": "npm run test && vite build --mode production && npm run generate:types && npm run build:live-demo",
     "build:live-demo": "vite build --mode live-demo --outDir ./live-demo",
     "preview": "vite preview",
     "deploy": "gh-pages -d github",
     "generate:types": "vue-tsc -p tsconfig-build.json --declaration --emitDeclarationOnly true --outdir ./dist",
     "changeset": "changeset",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:utils": "vitest run --mode broker",
-    "test:utils:watch": "vitest --mode broker",
+    "test": "vitest run --mode broker",
+    "test:watch": "vitest --mode broker",
+    "test:no-broker": "vitest run",
+    "test:no-broker:watch": "vitest",
     "test:coverage": "vitest run --mode broker --coverage"
   },
   "dependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ createApp(App)
         host: 'localhost',
         port: 9001,
         clientId: `ClientID-${Math.round(Math.random() * 9999)}`,
-        mainTopic: 'MAIN',
+        mainTopic: 'vue-paho-mqtt-test',
       },
     }),
   )

--- a/src/pahoMqttPlugin/config/client.ts
+++ b/src/pahoMqttPlugin/config/client.ts
@@ -1,6 +1,6 @@
 import { Client } from 'paho-mqtt';
 import { getMqttOptions } from './options';
-
+import { MqttOptions } from '../types';
 const MqttOptions = getMqttOptions();
 
 let client = new Client(
@@ -10,11 +10,17 @@ let client = new Client(
 );
 
 export const getClient = () => client;
-export const createClient = ({
-  host = MqttOptions.host,
-  port = MqttOptions.port,
-  clientId = MqttOptions.clientId,
-}) => {
-  client = new Client(host, port, clientId);
+export const createClient = (
+  options: MqttOptions = {
+    host: MqttOptions.host,
+    port: MqttOptions.port,
+    clientId: MqttOptions.clientId,
+  },
+) => {
+  client = new Client(
+    (MqttOptions.host = options.host),
+    (MqttOptions.port = options.port),
+    (MqttOptions.clientId = options.clientId),
+  );
   return client;
 };

--- a/src/pahoMqttPlugin/config/constants.ts
+++ b/src/pahoMqttPlugin/config/constants.ts
@@ -36,7 +36,7 @@ export const defaultMqttOptions: MqttOptions = {
   host: 'localhost',
   port: 9001,
   clientId: `ClientId-${Math.random() * 9999}`,
-  mainTopic: 'MAIN',
+  mainTopic: 'vue-paho-mqtt-test',
   enableMainTopic: true,
   watchdogTimeout: 2000,
   reconnectTimeout: 5000,

--- a/src/pahoMqttPlugin/utils/__tests__/utils.test.ts
+++ b/src/pahoMqttPlugin/utils/__tests__/utils.test.ts
@@ -3,12 +3,29 @@ import * as UTILS from '..';
 import { MQTT_STATE, defaultMqttOptions } from '../../config/constants';
 import { MqttMode } from '../../types';
 import { getMqttOptions } from '../../config/options';
+import { utilClient } from '../../../setupTests';
+import { createClient } from '../../config/client';
 
 describe.runIf(process.env.NODE_ENV === 'broker')('utils', () => {
   test('if status is set right before connection', () => {
     expect(UTILS.status()).toBe('disconnected');
   });
-
+  describe('Client', () => {
+    createClient({
+      host: utilClient.host,
+      port: utilClient.port,
+      clientId: utilClient.clientId,
+    });
+    test('if host set correctly', () => {
+      expect(UTILS.host()).toBe(utilClient.host);
+    });
+    test('if port set correctly', () => {
+      expect(UTILS.port()).toBe(utilClient.port);
+    });
+    test('if clientId set correctly', () => {
+      expect(UTILS.clientId()).toBe(utilClient.clientId);
+    });
+  });
   test(`if connects to the broker in ${defaultMqttOptions.watchdogTimeout}ms `, async () => {
     await expect(UTILS.connectClient()).resolves.toBe(true);
   });
@@ -53,7 +70,7 @@ describe.runIf(process.env.NODE_ENV === 'broker')('utils', () => {
           setTimeout(() => {
             UTILS.publish(topic, payload, mode);
             done();
-          }, 50);
+          }, 200);
         }),
     );
     test.concurrent('publish test message with Fnr mode', () => {

--- a/src/pahoMqttPlugin/utils/connectClient.ts
+++ b/src/pahoMqttPlugin/utils/connectClient.ts
@@ -43,11 +43,7 @@ export const connectClient = ({
     });
   }, MqttOptions.watchdogTimeout);
 
-  const client = createClient({
-    host: MqttOptions.host,
-    port: MqttOptions.port,
-    clientId: MqttOptions.clientId,
-  });
+  const client = createClient();
 
   client.onConnectionLost = (responseObject: { errorCode: number }) => {
     onConnectionLostCallback(responseObject);

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,12 +1,7 @@
 global.WebSocket = require('ws');
-
-import { beforeAll, beforeEach } from 'vitest';
-import { connectClient } from './pahoMqttPlugin/utils/connectClient';
-import { createClient } from './pahoMqttPlugin/config/client';
-import { unsubscribeAll } from './pahoMqttPlugin/utils/unsubscribeAll';
-
 export const mockClient = { host: 'localhost', port: 9001, clientId: 'mock' };
-
-beforeAll(() => {});
-
-beforeEach(() => {});
+export const utilClient = {
+  host: 'test.mosquitto.org',
+  port: 8080,
+  clientId: 'mock',
+};


### PR DESCRIPTION
Updated the contributing.md accordingly. npm run build, also runs the broker tests on mqtt://test.mosquitto.org:8080. createClient used to apply the mqtt option parameters only locally.