### PR TITLE
fix(connection): added timeout option to connection parameters

### DIFF
--- a/.changeset/chilled-cycles-leave.md
+++ b/.changeset/chilled-cycles-leave.md
@@ -1,0 +1,5 @@
+---
+"vue-paho-mqtt": patch
+---
+
+Added timeout option to the connection parameters.

--- a/src/pahoMqttPlugin/functions/onFailure.ts
+++ b/src/pahoMqttPlugin/functions/onFailure.ts
@@ -1,9 +1,11 @@
+import { disconnectClient } from '~/utils';
 import { SweetAlert } from '~/utils/SweetAlert';
 import { mqttStatus } from '~/utils/refs';
 
-export const onFailureCallback = (): void => {
+export const onFailureCallback = async (): Promise<void> => {
   mqttStatus.value = 'error';
   console.log('%cmqtt failed to connect', 'color:red');
+  await disconnectClient();
   SweetAlert({
     title: 'Mqtt Error',
     text: 'MQTT failed to connect',

--- a/src/pahoMqttPlugin/utils/connectClient.ts
+++ b/src/pahoMqttPlugin/utils/connectClient.ts
@@ -64,7 +64,7 @@ export const connectClient = ({
         userName: MqttOptions.username,
         password: MqttOptions.password,
         useSSL: MqttOptions.useSSL,
-        timeout: (MqttOptions.watchdogTimeout || 30) / 1000,
+        timeout: (MqttOptions.watchdogTimeout || 30000) / 1000,
         uris: [
           `wss://${MqttOptions.host}:${MqttOptions.port}${MqttOptions.path}`,
           `ws://${MqttOptions.host}:${MqttOptions.port}${MqttOptions.path}`,

--- a/src/pahoMqttPlugin/utils/connectClient.ts
+++ b/src/pahoMqttPlugin/utils/connectClient.ts
@@ -73,6 +73,7 @@ export const connectClient = ({
         userName: MqttOptions.username,
         password: MqttOptions.password,
         useSSL: MqttOptions.useSSL,
+        timeout: MqttOptions.watchdogTimeout,
         uris: [
           `wss://${MqttOptions.host}:${MqttOptions.port}${MqttOptions.path}`,
           `ws://${MqttOptions.host}:${MqttOptions.port}${MqttOptions.path}`,


### PR DESCRIPTION
I figured that without this option the promise continues to exist and rejects after the default 30 second timeout.

https://eclipse.dev/paho/files/jsdoc/Paho.MQTT.Client.html